### PR TITLE
flasher scripts: add `sim_services` import dependency.

### DIFF
--- a/resources/scripts/flasher/StandardCandle/generateTestFlashesSC.py
+++ b/resources/scripts/flasher/StandardCandle/generateTestFlashesSC.py
@@ -29,7 +29,7 @@ from I3Tray import *
 import os
 import sys
 
-from icecube import icetray, dataclasses, dataio, phys_services, clsim
+from icecube import icetray, dataclasses, dataio, phys_services, clsim, sim_services
 
 import math
 import numpy

--- a/resources/scripts/flasher/generateTestFlashes.py
+++ b/resources/scripts/flasher/generateTestFlashes.py
@@ -29,7 +29,7 @@ from I3Tray import *
 import os
 import sys
 
-from icecube import icetray, dataclasses, dataio, phys_services, clsim
+from icecube import icetray, dataclasses, dataio, phys_services, clsim, sim_services
 
 import math
 import numpy


### PR DESCRIPTION
In `simulation-04-00-06-rc`, the module `I3MCEventHeaderGenerator`, which is required by the scripts, probably has been moved to the `sim-services` package. Without this modification the following error would occur:

> FATAL (icetray): Module/service "I3MCEventHeaderGenerator" not registered with I3_MODULE() or I3_SERVICE_FACTORY() (I3Factory.h:83 in FactoryFn I3Factory<Product, FactoryFn>::Create(std::string) const [with Product = I3Module, FactoryFn = boost::functionboost::shared_ptr<I3Module(const I3Context&)>])

This commit resolves this issue.

The change is also compatible to simulation 3.
